### PR TITLE
Fix naming conflict between the main module and Paperclip processor 

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,9 +55,10 @@ pdf to image feature.
 After cloning this gem locally just run the `bin/setup` script to set everything
 up. This will:
 
-- Run `bundle` to install the development dependencies
+- Run `bundle` to install the development dependencies.
 - Initialize the database used by the `spec/dummy` rails application that
 we use to test the ActiveRecord+(Paperclip|CarrierWave) integration.
+- Generate JPEG files used in the specs.
 
 ## Running the specs
 

--- a/Rakefile
+++ b/Rakefile
@@ -4,7 +4,10 @@ require "rubocop/rake_task"
 
 ENV["RAILS_ENV"] ||= "test"
 
-RSpec::Core::RakeTask.new(:spec)
+RSpec::Core::RakeTask.new(:spec).tap do |rspec_task|
+  rspec_task.rspec_opts = "--fail-fast"
+  rspec_task.rspec_opts += " --seed #{ENV['SEED']}" if ENV["SEED"]
+end
 
 RuboCop::RakeTask.new(:rubocop)
 

--- a/Rakefile
+++ b/Rakefile
@@ -4,9 +4,7 @@ require "rubocop/rake_task"
 
 ENV["RAILS_ENV"] ||= "test"
 
-RSpec::Core::RakeTask.new(:spec).tap do |rspec_task|
-  rspec_task.rspec_opts = "--fail-fast"
-end
+RSpec::Core::RakeTask.new(:spec)
 
 RuboCop::RakeTask.new(:rubocop)
 

--- a/lib/paperclip/pdf_cover_processor.rb
+++ b/lib/paperclip/pdf_cover_processor.rb
@@ -9,7 +9,7 @@ if Kernel.const_defined?(:Paperclip)
     #   @file the file that will be operated on (which is an instance of File)
     #   @options a hash of options that were defined in has_attached_file's style hash
     #   @attachment the Paperclip::Attachment itself
-    class PdfCover < Processor
+    class PdfCoverProcessor < Processor
       QUALITY_CONVERT_OPTION_REGEX = /-quality\s+(?<quality>\d+)/
       RESOLUTION_CONVERT_OPTION_REGEX = /-density\s+(?<resolution>\d+)/
 

--- a/lib/pdf_cover.rb
+++ b/lib/pdf_cover.rb
@@ -60,7 +60,7 @@ module PdfCover
       #     validates_attachment_content_type :pdf, content_type: %w(application/pdf)
       #   end
       def pdf_cover_attachment(attachment_name, options = {})
-        options[:processors] = (options[:processors] || []).unshift(:pdf_cover)
+        options[:processors] = (options[:processors] || []).unshift(:pdf_cover_processor)
 
         has_attached_file attachment_name, options
       end
@@ -72,6 +72,7 @@ module PdfCover
       if carrierwave_defined?(base)
         base.extend ClassMethods::CarrierWave
       elsif paperclip_defined?
+        require "paperclip/pdf_cover_processor"
         base.extend ClassMethods::Paperclip
       else
         fail "#{base} is not a CarrierWave::Uploader and Paperclip is not defined ¯\\_(ツ)_/¯"

--- a/spec/dummy/app/models/with_paperclip.rb
+++ b/spec/dummy/app/models/with_paperclip.rb
@@ -1,5 +1,3 @@
-require "paperclip/pdf_cover"
-
 class WithPaperclip < ActiveRecord::Base
   include PdfCover
 


### PR DESCRIPTION
We declared a main module named PdfCover and then a Paperclip processor named the same. In some situation it caused Paperclip to blow up when using the gem.

I've renamed the processor to PdfCoverProcessor to fix that.
