### PR TITLE
Raise new error if GS execution fails

### DIFF
--- a/lib/pdf_cover/converter.rb
+++ b/lib/pdf_cover/converter.rb
@@ -7,6 +7,9 @@ module PdfCover
     DEFAULT_QUALITY = 85
     DEFAULT_RESOLUTION = 300
 
+    COMMAND_EXECUTION_SUCCESS_CODE = 0
+    COMMAND_NOT_FOUND_CODE = 127 # @see http://www.tldp.org/LDP/abs/html/exitcodes.html
+
     class CommandFailedError < StandardError
       def initialize(stdout_str, stderr_str)
         super("PDF conversion failed:\nSTDOUT: #{stdout_str}\nSTDERR: #{stderr_str}")
@@ -37,8 +40,8 @@ module PdfCover
       stdout_str, stderr_str, status = execute_command("gs #{parameters}")
 
       case status
-        when 0 then destination_file
-        when 127 then fail CommandNotFoundError
+        when COMMAND_EXECUTION_SUCCESS_CODE then destination_file
+        when COMMAND_NOT_FOUND_CODE then fail CommandNotFoundError
         else fail CommandFailedError.new(stdout_str, stderr_str)
       end
     rescue => e

--- a/lib/pdf_cover/converter.rb
+++ b/lib/pdf_cover/converter.rb
@@ -1,9 +1,17 @@
+require "open3"
+
 module PdfCover
   class Converter
     # NOTE: Update the generate_jpegs.sh script when changing these values
     DEFAULT_FORMAT = "jpeg"
     DEFAULT_QUALITY = 85
     DEFAULT_RESOLUTION = 300
+
+    class CommandFailedError < StandardError
+      def initialize(stdout_str, stderr_str)
+        super("PDF conversion failed:\nSTDOUT: #{stdout_str}\nSTDERR: #{stderr_str}")
+      end
+    end
 
     class CommandNotFoundError < StandardError
       def initialize
@@ -23,15 +31,19 @@ module PdfCover
     end
 
     # @raises PdfCover::Converter::CommandNotFoundError if GhostScript is not found
+    # @raises PdfCover::Converter::CommandFailedError if GhostScript returns a non-zero status
     def converted_file
-      case convert_file
-        when :ok
-          destination_file
-        when :command_failed
-          @file
-        when :command_not_found
-          fail CommandNotFoundError
+      parameters = build_parameters(file_path, device)
+      stdout_str, stderr_str, status = execute_command("gs #{parameters}")
+
+      case status
+        when 0 then destination_file
+        when 127 then fail CommandNotFoundError
+        else fail CommandFailedError.new(stdout_str, stderr_str)
       end
+    rescue => e
+      destination_file.close
+      raise e
     end
 
     private
@@ -40,24 +52,13 @@ module PdfCover
       @basename ||= File.basename(@file.path, File.extname(@file.path))
     end
 
-    def build_parameters(source, device, destination)
-      %W(-sOutputFile='#{destination}' -dNOPAUSE
+    def build_parameters(source, device)
+      %W(-sOutputFile='#{destination_path}' -dNOPAUSE
          -sDEVICE='#{device}' -dJPEGQ=#{@quality}
          -dFirstPage=1 -dLastPage=1
          -r#{@resolution} -q '#{source}'
          -c quit
       ).join(" ")
-    end
-
-    def convert_file
-      parameters = build_parameters(file_path, device, File.expand_path(destination_file.path))
-      result = execute_command("gs #{parameters}")
-
-      if result
-        :ok
-      else
-        failed_result(result)
-      end
     end
 
     def destination_file
@@ -66,12 +67,16 @@ module PdfCover
       end
     end
 
+    def destination_path
+      File.expand_path(destination_file.path)
+    end
+
     def device
       @format.to_s == "jpg" ? "jpeg" : @format.to_s
     end
 
     def execute_command(command)
-      Kernel.system(command)
+      Open3.capture3(command)
     end
 
     def extract_options(options)
@@ -84,23 +89,8 @@ module PdfCover
       fail InvalidOption.new(:resolution, @resolution) unless @resolution > 1
     end
 
-    def failed_result(result)
-      destination_file.close
-
-      if result == false
-        logger.warn("GhostScript execution failed: #{$CHILD_STATUS}")
-        :command_failed
-      else
-        :command_not_found
-      end
-    end
-
     def file_path
       @file_path ||= File.expand_path(@file.path)
-    end
-
-    def logger
-      @logger ||= defined?(Rails) ? Rails.logger : Logger.new(STDERR)
     end
   end
 end

--- a/spec/xing/pdf_cover/converter_spec.rb
+++ b/spec/xing/pdf_cover/converter_spec.rb
@@ -80,7 +80,7 @@ describe PdfCover::Converter do
       end
 
       context "the conversion goes fine" do
-        let(:execution_result) { true }
+        let(:execution_result) { ["", "", 0] }
 
         it "returns the generated file" do
           expect(subject.converted_file).to eq(destination_file)
@@ -93,23 +93,16 @@ describe PdfCover::Converter do
         end
 
         context "because the command execution failed" do
-          let(:execution_result) { false }
+          let(:execution_result) { ["", "", 1] }
           let(:logger) { double(Logger) }
 
-          const_set(:CHILD_STATUS, "something went wrong")
-
-          before do
-            expect(subject).to receive(:logger).and_return(logger)
-            expect(logger).to receive(:warn)
-          end
-
-          it "returns the original file" do
-            expect(subject.converted_file).to eq(source_file)
+          it "generates an error" do
+            expect { subject.converted_file }.to raise_error(PdfCover::Converter::CommandFailedError)
           end
         end
 
         context "because the GhostScript command is not found" do
-          let(:execution_result) { nil }
+          let(:execution_result) { ["", "", 127] }
 
           it "generates an error" do
             expect { subject.converted_file }.to raise_error(PdfCover::Converter::CommandNotFoundError)


### PR DESCRIPTION
Up until now, if the ghostscript execution failed, then it would just return the original file, but this is problematic as it means that eventually Carrierwave (and probably paperclip too) is going to try to copy a file over itself and fail.

With the changes in this PR, now we raise a specific exception with details about why GS failed that can be rescued by whoever is trying to save the record and handled accordingly.

Since this change introduces a new backwards compatible API, a new minor version needs to be released.
