### PR TITLE
handle quote on windows

### DIFF
--- a/lib/pdf_cover/converter.rb
+++ b/lib/pdf_cover/converter.rb
@@ -57,11 +57,11 @@ module PdfCover
     end
 
     def build_parameters(source, device)
-      %W(-sOutputFile='#{destination_path}' -dNOPAUSE
-         -sDEVICE='#{device}' -dJPEGQ=#{@quality}
+      %W(-sOutputFile="#{destination_path}" -dNOPAUSE
+         -sDEVICE="#{device}" -dJPEGQ=#{@quality}
          -dFirstPage=1 -dLastPage=1
          -dGraphicsAlphaBits=#{@antialiasing}
-         -r#{@resolution} -q '#{source}'
+         -r#{@resolution} -q "#{source}"
          -c quit
       ).join(" ")
     end


### PR DESCRIPTION
hi guys I found different behavior on windows, when use single quote it will raise error and should be use double quotes for parameters

`gs -dNOPAUSE -sDEVICE='jpeg' -dJPEGQ=85 -sOutputFile=test.jpg -dGraphicsAlphaBits=4 -r300 -q pdf.pdf -c quit`
Unknown device: 'jpeg'

`gs -dNOPAUSE -sDEVICE="jpeg" -dJPEGQ=85 -sOutputFile=test.jpg -dGraphicsAlphaBits=4 -r300 -q pdf.pdf -c quit`
worked well