### PR TITLE
Set correct mime type for cover

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -16,11 +16,6 @@ AllCops:
     - 'db/migrate/*.rb'
     - 'spec/dummy/**/*'
 
-  # By default, the rails cops are not run. Override in project or home
-  # directory .rubocop.yml files, or by giving the -R/--rails option.
-  Rails:
-    Enabled: true
-
 # Indent private/protected/public as deep as method definitions
 AccessModifierIndentation:
   Description: Check indentation of private/protected visibility modifiers.

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: ruby
 rvm:
-  - 2.2.6
-  - 2.3.4
+  - 2.5.7
+  - 2.6.5
 gemfile:
   - gemfiles/4.2.gemfile
   - gemfiles/5.0.gemfile

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,26 @@ All notable changes to this project will be documented in this file.
 
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.3.1] - 2019-11-26
+### Added
+- Enforce JPEG content type for carrierwave [Pull Request](https://github.com/xing/pdf_cover/pull/10)
+
+## [0.2.4] - 2017-10-18
+### Added
+- Handle quotes in windows when calling GS [Pull Request](https://github.com/xing/pdf_cover/pull/9)
+
+## [0.2.3] - 2017-08-21
+### Added
+- Remove `dTextAlphaBits` parameter to GS [Pull Request](https://github.com/xing/pdf_cover/pull/8)
+
+## [0.2.3] - 2017-08-21
+### Added
+- Remove `dTextAlphaBits` parameter to GS [Pull Request](https://github.com/xing/pdf_cover/pull/8)
+
+## [0.2.2] - 2017-07-05
+### Added
+- Add support for rails 5 [Pull Request](https://github.com/xing/pdf_cover/pull/7)
+
 ## [0.2.1] - 2016-10-24
 ### Added
 - Add default antialias [Pull Request](https://github.com/xing/pdf_cover/pull/6)

--- a/lib/pdf_cover.rb
+++ b/lib/pdf_cover.rb
@@ -31,6 +31,7 @@ module PdfCover
       #   end
       def pdf_cover_attachment(options = {})
         process pdf_cover: [options[:quality], options[:resolution]]
+        process enforce_content_type: "image/jpeg"
 
         define_method :full_filename do |for_file = model.logo.file|
           for_file.gsub(/pdf$/i, "jpeg")
@@ -95,5 +96,9 @@ module PdfCover
     options = { quality: quality, resolution: resolution }.compact
     converted_file = PdfCover::Converter.new(file, options).converted_file
     FileUtils.cp(converted_file, current_path)
+  end
+
+  def enforce_content_type(content_type)
+    file.content_type = content_type
   end
 end

--- a/lib/pdf_cover/version.rb
+++ b/lib/pdf_cover/version.rb
@@ -1,3 +1,3 @@
 module PdfCover
-  VERSION = "0.2.4".freeze
+  VERSION = "0.3.1".freeze
 end

--- a/pdf_cover.gemspec
+++ b/pdf_cover.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "activesupport", ">= 4.2"
+  spec.add_development_dependency "activesupport", ">= 4.2", "< 6.0.0"
 
   spec.add_development_dependency "appraisal"
 
@@ -32,7 +32,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "simplecov"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "rubocop", "~> 0.37.2"
-  spec.add_development_dependency "sqlite3"
+  spec.add_development_dependency "sqlite3", "~> 1.3.6"
 
   spec.add_development_dependency "byebug"
   spec.add_development_dependency "fivemat"

--- a/spec/carrierwave/with_carrierwave_spec.rb
+++ b/spec/carrierwave/with_carrierwave_spec.rb
@@ -8,6 +8,7 @@ describe WithCarrierwave do
     let(:pdf_cover) { Magick::Image.read(pdf_cover_path).first }
     let(:pdf_cover_digest) { pdf_cover.signature }
     let(:pdf_cover_path) { subject.pdf.image.path }
+    let(:pdf_cover_content_type) { subject.pdf.image.content_type }
 
     let(:sample_image) { Magick::Image.read(sample_image_name).first }
     let(:sample_image_digest) { sample_image.signature }
@@ -22,6 +23,7 @@ describe WithCarrierwave do
       it "creates the pdf cover image" do
         expect(pdf_cover_path).to match(/.*jpeg$/)
         expect(pdf_cover_digest).to eq(sample_image_digest)
+        expect(pdf_cover_content_type).to eq("image/jpeg")
       end
     end
 

--- a/spec/dummy/config/environment.rb
+++ b/spec/dummy/config/environment.rb
@@ -1,5 +1,5 @@
 # Load the Rails application.
-require File.expand_path('../application', __FILE__)
+require File.expand_path("../application", __FILE__)
 
 require "paperclip"
 require "carrierwave"


### PR DESCRIPTION
When generating the cover in the supported version of carrierwave, the content type is set to the one from the original file (PDF), not from the transformed one.

This generates CORB issues when serving the images inside iframes, so here I enforce the content type of the generated file manually.

I also add the missing entries to the changelog and do some minimal adaptation to the current versions of some dependencies.