### PR TITLE
Update carrierwave + drop support for Rails 4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,10 @@ language: ruby
 rvm:
   - 2.5.8
   - 2.6.6
+  - 2.7.2
 gemfile:
-  - gemfiles/4.2.gemfile
   - gemfiles/5.0.gemfile
+  - gemfiles/6.0.gemfile
 before_install:
   - gem install bundler -v 1.11.2
   - sudo apt-get -qq update

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [1.0.0] - 2021-02-11
+### Breaking change
+- Drop support for Rails 4.x [Pull Request](https://github.com/xing/pdf_cover/pull/12)
+
 ## [0.3.2] - 2020-11-06
 ### Changed
 - Update dependencies with security vulnerabilities detected [Pull Request](https://github.com/xing/pdf_cover/pull/11)

--- a/gemfiles/5.0.gemfile
+++ b/gemfiles/5.0.gemfile
@@ -2,6 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "rails", "~> 5.0.0"
+gem "rails", "~> 5.2.4"
 
 gemspec path: "../"

--- a/gemfiles/6.0.gemfile
+++ b/gemfiles/6.0.gemfile
@@ -2,6 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "rails", "~> 4.2.0"
+gem "rails", "~> 6.1.2"
 
 gemspec path: "../"

--- a/lib/pdf_cover.rb
+++ b/lib/pdf_cover.rb
@@ -11,7 +11,7 @@ module PdfCover
   module ClassMethods
     module CarrierWave
       # When called in the context of a CarrierWave::Uploader::Base subclass,
-      # this method will add a processor to the currenct attachment or version
+      # this method will add a processor to the current attachment or version
       # that generates a JPEG with 95 quality from the first page of the given
       # PDF.
       #

--- a/lib/pdf_cover/version.rb
+++ b/lib/pdf_cover/version.rb
@@ -1,3 +1,3 @@
 module PdfCover
-  VERSION = "0.3.2".freeze
+  VERSION = "1.0.0".freeze
 end

--- a/pdf_cover.gemspec
+++ b/pdf_cover.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "activesupport", ">= 4.2", "< 6.0.3.1"
+  spec.add_development_dependency "activesupport", ">= 5.0"
 
   spec.add_development_dependency "appraisal"
 
@@ -33,14 +33,14 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "simplecov"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "rubocop", "~> 0.49.0"
-  spec.add_development_dependency "sqlite3", "~> 1.3.6"
+  spec.add_development_dependency "sqlite3", "~> 1.4"
 
   spec.add_development_dependency "byebug"
   spec.add_development_dependency "fivemat"
   spec.add_development_dependency "coveralls_reborn"
 
   spec.add_development_dependency "paperclip", "=6.1.0"
-  spec.add_development_dependency "carrierwave", "~> 2.1"
+  spec.add_development_dependency "carrierwave", "~> 1.3.2"
 
   spec.add_development_dependency "rmagick", "~> 2.13.2"
 

--- a/pdf_cover.gemspec
+++ b/pdf_cover.gemspec
@@ -40,7 +40,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "coveralls_reborn"
 
   spec.add_development_dependency "paperclip", "=6.1.0"
-  spec.add_development_dependency "carrierwave", "~> 0.10"
+  spec.add_development_dependency "carrierwave", "~> 2.1"
 
   spec.add_development_dependency "rmagick", "~> 2.13.2"
 


### PR DESCRIPTION
Update `carrierwave` dependency due to a security issue [CVE-2021-21288]. 

I had to drop support for Rails 4 since the newer version of `carrierwave` doesn't support it.